### PR TITLE
Basic dockerisation & minor improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+e2e/
+dist/
+node_modules/
+.git/
+
+.dockerignore
+.editorconfig
+.gitignore
+Dockerfile
+README.md
+LICENSE
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,4 @@ dist
 
 # Project specific files
 config.json
-corporallancot.code-workspace
+invite.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Node Bot Dockerfile
+
+#---------------------
+FROM node:lts-alpine3.9
+WORKDIR /bot
+
+COPY package.json /bot
+COPY package-lock.json /bot
+
+RUN set -x \
+    && npm -v \
+    && npm set progress=false \
+    && npm install --no-progress
+
+COPY /config.json /bot
+COPY /app.js /bot
+COPY /app /bot/app
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # Corporal Lancot
-A Discord bot primarily for recording, searching and retrieving notes and quotes.
+
+A dockerised Discord bot written in Node.js, primarily for recording, searching and retrieving notes and quotes from a database. This project currently uses MariaDB as a backing store.
+
+## To Run
+
+* Create a discord application & bot:
+  * https://discord.com/developers/applications
+  * The bot requests the following permissions:
+    * General Permissions: View channels
+    * Text Permissions: Send Messages, Embed links, Attach Files, Mention Everyone
+    * This results in a permssions integer of 183296
+* Create a .env file in the project root:
+```
+DB_LOCAL_PORT=3306
+DB_MOUNT_PATH=<YOUR_MOUNT_PATH>
+MYSQL_ROOT_PASSWORD=<YOUR_ROOT_PW>
+MYSQL_USER=notes
+MYSQL_PASSWORD=<NOTES_USER_PW>
+MYSQL_DATABASE=notes
+```
+* Where:
+  * `<YOUR_MOUNT_PATH>` is the host machine path where the database files will be persisted. On a Windows host you can use something like `d:/docker-mounts/corporallancot.db`, on a Linux host `/docker-mounts/corporallancot.db`.
+  * `<YOUR_ROOT_PW>` is the database's root password. This is for administrative purposes only. The root user is not used by the application.
+  * `<NOTES_USER_PW>` is the database's `notes` user password. This is the account that the application uses to connect to the database.
+
+* Create a `config.json` file in the project root with the following contents:
+```
+{
+  "key": "<DISCORD_BOT_TOKEN>",
+  "db": "notes",
+  "dbTable": "notes",
+  "dbHost": "corporallancot.db",
+  "dbUser": "notes",
+  "dbPassword": "<NOTES_USER_PW>"
+}
+```
+* Where:
+  * `<DISCORD_BOT_TOKEN>` is the bot's authorisation token from the Discord Developer Portal
+  * `<NOTES_USER_PW>` is the database `notes` user's password
+* Install Docker
+* Run the following cli command to start the bot:
+```
+docker-compose up -d
+```
+* Send a request to invite the bot to your server:
+  * `https://discord.com/api/oauth2/authorize?client_id=<YOUR_CLIENT_ID>&scope=bot&permissions=183296`
+    * Where:
+      * `<YOUR_CLIENT_ID>` is the ID of the Discord application
+* Select your server, grant permissions and the bot will join
+
+## Bot Usage
+* Use `!notes <message>` to log a message
+* Use `!quote` to retrieve a random message from the notes archive
+* Use `!quote <search term>` to retrieve a message using a basic search
+* Use `!help` to show a help message

--- a/app.js
+++ b/app.js
@@ -1,10 +1,14 @@
 const Bot = require("./app/bot");
 const fs = require("fs");
-console.log("Checking config...");
+console.log("Checking config");
 const config = JSON.parse(fs.readFileSync("config.json"));
 if (!config) {
-  throw new Error("Config not found or unreadable!");
+  throw new Error("Config not found or unreadable");
 }
-console.log("Config loaded!");
+console.log("Config loaded");
 
 const bot = new Bot(config);
+
+(async () => {
+  await bot.init();
+})();

--- a/config-example.json
+++ b/config-example.json
@@ -1,8 +1,0 @@
-{
-  "key": "000000000000000000000000.000000.000000000000000000000000000",
-  "db": "notes",
-  "dbTable": "notes",
-  "dbHost": "localhost",
-  "dbUser": "root",
-  "dbPassword": ""
-}

--- a/corporallancot.code-workspace
+++ b/corporallancot.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+    ],
+    "settings": {
+        "editor.tabSize": 2
+    }
+}

--- a/corporallancot.code-workspace
+++ b/corporallancot.code-workspace
@@ -1,10 +1,10 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-    ],
-    "settings": {
-        "editor.tabSize": 2
+  "folders": [
+    {
+      "path": "."
     }
+  ],
+  "settings": {
+    "editor.tabSize": 2
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.1"
+
+services:
+  db:
+    image: mariadb:10.5.3
+    container_name: corporallancot.db
+    ports:
+      - "${DB_LOCAL_PORT}:3306"
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    volumes:
+      - ${DB_MOUNT_PATH}:/var/lib/mysql
+  bot:
+    image: corporallancot:latest
+    container_name: corporallancot.bot
+    depends_on:
+      - db
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped


### PR DESCRIPTION
- Added and configured docker-compose.yml to include basic MariaDB setup
- Added Dockerfile & .diockerignore for building the Node.js Bot host image
- Updated README.md to detail bot setup instructions
- Deleted config-example.json as example now resides in README.md
- Fixed a bug in the notes table setup promise wrapper handling
- Added / improved some logging
- Improved error handling slightly; removed some unhelpful try-catch statements & removed bot.init() call from constructor -> moved it out into an asynchronous call from app.js
- Removed *some* of the exclamations and ellipses from log messages 8==============D
- Added a shared .code-workspace file to avoid formatting faux pas
- Bot should now work "out of the box" with no installs / configuration required other than those in README.md