### PR TITLE
Resolves #13 - Implemented Maria DB Auto Execution of Docker SQL Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ dist
 # Project specific files
 config.json
 invite.txt
+# The below directory is mounted to DB_SQL_SCRIPTS_MOUNT_PATH
+.sql/

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ A dockerised Discord bot written in Node.js, primarily for recording, searching 
 * Create a .env file in the project root:
 ```
 DB_LOCAL_PORT=3306
-DB_MOUNT_PATH=<YOUR_MOUNT_PATH>
+DB_MOUNT_PATH=<DATABASE_MOUNT_PATH>
+DB_SQL_SCRIPTS_MOUNT_PATH=<SCRIPTS_MOUNT_PATH>
 MYSQL_ROOT_PASSWORD=<YOUR_ROOT_PW>
 MYSQL_USER=notes
 MYSQL_PASSWORD=<NOTES_USER_PW>
 MYSQL_DATABASE=notes
 ```
 * Where:
-  * `<YOUR_MOUNT_PATH>` is the host machine path where the database files will be persisted. On a Windows host you can use something like `d:/docker-mounts/corporallancot.db`, on a Linux host `/docker-mounts/corporallancot.db`.
+  * `<DATABASE_MOUNT_PATH>` is the host machine path where the database files will be persisted. On a Windows host you can use something like `d:/docker-mounts/corporallancot.db`, on a Linux host `/docker-mounts/corporallancot.db`.
+  * `<SCRIPTS_MOUNT_PATH>` is the host machine path where any SQL scripts that need to be executed after the container is created are located. See [Initializing a fresh instance on this page](https://hub.docker.com/_/mariadb/) for more information. This is useful for running ETL and / or custom setup scripts for the database. This can be an empty directory and follows the same rules as `<DATABASE_MOUNT_PATH>`. The [.gitignore](.gitignore) file for this project implies that custom database setup scripts should be kept in the `.sql` directory in the root; on Windows the mount path would be something similar to `D:/Git/Personal/corporallancot/.sql`.
   * `<YOUR_ROOT_PW>` is the database's root password. This is for administrative purposes only. The root user is not used by the application.
   * `<NOTES_USER_PW>` is the database's `notes` user password. This is the account that the application uses to connect to the database.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
     volumes:
       - ${DB_MOUNT_PATH}:/var/lib/mysql
+      - ${DB_SQL_SCRIPTS_MOUNT_PATH}:/docker-entrypoint-initdb.d
   bot:
     image: corporallancot:latest
     container_name: corporallancot.bot


### PR DESCRIPTION
This was actually a lot simpler than I thought it would be - I was expecting to have to create and customise our own MariaDB Dockerfile, but the default one already had capability.

A few additional steps are required to get the old SQS notes importing. These are not documented as part of the OSS source as they are project specific. Give me a shout when you need to go over this.