### PR TITLE
Feature/19 GitHub actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2020": true,
+        "jasmine": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 11
+    },
+    "rules": {
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,14 @@
 {
-    "env": {
-        "browser": true,
-        "commonjs": true,
-        "es2020": true,
-        "jasmine": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": 11
-    },
-    "rules": {
-    }
+  "env": {
+    "node": true,
+    "browser": false,
+    "commonjs": false,
+    "es2020": true,
+    "jasmine": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 11
+  },
+  "rules": {}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,5 +10,7 @@
   "parserOptions": {
     "ecmaVersion": 11
   },
-  "rules": {}
+  "rules": {
+    "indent": ["warn", 2]
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  # IMAGE_TAG: 2.0.3 # For testing purposes only. Dealt with in the "Get image tags" task.
+  DOCKER_REGISTRY: docker.pkg.github.com
+  BOT_IMAGE: docker.pkg.github.com/lewster32/corporallancot/corporallancot-bot # Cannot use variable references here - hence repeat info
+  DB_IMAGE: docker.pkg.github.com/lewster32/corporallancot/corporallancot-db
+
+  # docker-compose.yml file required environment variables for just build
+  DB_LOCAL_PORT: 3306
+
 jobs:
   corporallancot:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   DB_IMAGE: docker.pkg.github.com/lewster32/corporallancot/corporallancot-db
 
   # docker-compose.yml file required environment variables for just build
-  DB_LOCAL_PORT: 3306
+  BOT_DB_LOCAL_PORT: 3306
 
 jobs:
   corporallancot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Corporal Lancot CI Build
+
+on:
+  push:
+    branches: [ master, feature/* ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  corporallancot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install Node Dependencies
+      working-directory: ./
+      run: |
+        npm set progress=false
+        npm install --no-progress
+    - name: Linter
+      working-directory: ./
+      run: npm run lint
+    - name: Jasmine Tests
+      working-directory: ./
+      run: npm run test
+    - name: Build Docker
+      working-directory: ./
+      run: |
+          set -x;
+          docker-compose build;

--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ dist
 .tern-port
 
 # Project specific files
-config.json
 invite.txt
-# The below directory is mounted to DB_SQL_SCRIPTS_MOUNT_PATH
+
+# The below directory is mounted to BOT_DB_SQL_SCRIPTS_MOUNT_PATH
 .sql/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY /config.json /bot
 COPY /index.js /bot
 COPY /app /bot/app
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "start:hosted"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Corporal Lancot
 
+![License](https://img.shields.io/github/license/lewster32/corporallancot)
+![Version](https://img.shields.io/github/package-json/v/lewster32/corporallancot)
+![CI Build](https://img.shields.io/github/workflow/status/lewster32/corporallancot/Corporal%20Lancot%20CI%20Build?label=CI%20Build)
+![CD Build](https://img.shields.io/github/workflow/status/lewster32/corporallancot/Corporal%20Lancot%20CD%20Build?label=CD%20Build)
+![Issues Open](https://img.shields.io/github/issues/lewster32/corporallancot)
+![PRs Open](https://img.shields.io/github/issues-pr/lewster32/corporallancot)
+![Last Commit](https://img.shields.io/github/last-commit/lewster32/corporallancot)
+
 A containerised Discord bot written in Node.js, primarily for recording, searching and retrieving notes and quotes from a database. This project currently uses MariaDB as a backing store.
 
 ## To Run

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Corporal Lancot
 
-A dockerised Discord bot written in Node.js, primarily for recording, searching and retrieving notes and quotes from a database. This project currently uses MariaDB as a backing store.
+A containerised Discord bot written in Node.js, primarily for recording, searching and retrieving notes and quotes from a database. This project currently uses MariaDB as a backing store.
 
 ## To Run
 
@@ -12,34 +12,22 @@ A dockerised Discord bot written in Node.js, primarily for recording, searching 
     * This results in a permssions integer of 183296
 * Create a .env file in the project root:
 ```
-DB_LOCAL_PORT=3306
-DB_MOUNT_PATH=<DATABASE_MOUNT_PATH>
-DB_SQL_SCRIPTS_MOUNT_PATH=<SCRIPTS_MOUNT_PATH>
+BOT_DISCORD_KEY=<YOUR_DISCORD_TOKEN>
+BOT_DB_LOCAL_PORT=3306
+BOT_DB_SERVER=corporallancot.db
+BOT_DB_MOUNT_PATH=<DATABASE_MOUNT_PATH>
+BOT_DB_SQL_SCRIPTS_MOUNT_PATH=<SCRIPTS_MOUNT_PATH>
 MYSQL_ROOT_PASSWORD=<YOUR_ROOT_PW>
 MYSQL_USER=notes
 MYSQL_PASSWORD=<NOTES_USER_PW>
 MYSQL_DATABASE=notes
 ```
 * Where:
+  * `<YOUR_DISCORD_TOKEN>` is the token for your discord bot.
   * `<DATABASE_MOUNT_PATH>` is the host machine path where the database files will be persisted. On a Windows host you can use something like `d:/docker-mounts/corporallancot.db`, on a Linux host `/docker-mounts/corporallancot.db`.
   * `<SCRIPTS_MOUNT_PATH>` is the host machine path where any SQL scripts that need to be executed after the container is created are located. See [Initializing a fresh instance on this page](https://hub.docker.com/_/mariadb/) for more information. This is useful for running ETL and / or custom setup scripts for the database. This can be an empty directory and follows the same rules as `<DATABASE_MOUNT_PATH>`. The [.gitignore](.gitignore) file for this project implies that custom database setup scripts should be kept in the `.sql` directory in the root; on Windows the mount path would be something similar to `D:/Git/Personal/corporallancot/.sql`.
   * `<YOUR_ROOT_PW>` is the database's root password. This is for administrative purposes only. The root user is not used by the application.
   * `<NOTES_USER_PW>` is the database's `notes` user password. This is the account that the application uses to connect to the database.
-
-* Create a `config.json` file in the project root with the following contents:
-```
-{
-  "key": "<DISCORD_BOT_TOKEN>",
-  "db": "notes",
-  "dbTable": "notes",
-  "dbHost": "corporallancot.db",
-  "dbUser": "notes",
-  "dbPassword": "<NOTES_USER_PW>"
-}
-```
-* Where:
-  * `<DISCORD_BOT_TOKEN>` is the bot's authorisation token from the Discord Developer Portal
-  * `<NOTES_USER_PW>` is the database `notes` user's password
 * Install Docker
 * Run the following cli command to start the bot:
 ```
@@ -50,6 +38,8 @@ docker-compose up -d
     * Where:
       * `<YOUR_CLIENT_ID>` is the ID of the Discord application
 * Select your server, grant permissions and the bot will join
+
+_**Do not push sensitive information to the repo in config.json**_
 
 ## Bot Usage
 * Use `!notes <message>` to log a message

--- a/app/actions/actionHandlerBase.js
+++ b/app/actions/actionHandlerBase.js
@@ -14,7 +14,7 @@ module.exports = class ActionHandlerBase {
     return (this.command && this.command === action.command);
   }
 
-  async handle(action, msg) {
+  async handle() {
     throw NotImplemented;
   }
 };

--- a/app/actions/handlers/helpActionHandler.js
+++ b/app/actions/handlers/helpActionHandler.js
@@ -3,14 +3,13 @@
 const ActionHandlerBase = require("@actions/actionHandlerBase");
 
 module.exports = class HelpActionHandler extends ActionHandlerBase {
-  help = "`!help` to show this message.";
-
   constructor({ logger, helpActionActions }) {
     super(logger, "help");
     this.actions = helpActionActions;
+    this.help = "`!help` to show this message.";
   }
 
-  async handle(action, msg) {
+  async handle(action) {
     if (!action) {
       return;
     }

--- a/app/actions/handlers/notesActionHandler.js
+++ b/app/actions/handlers/notesActionHandler.js
@@ -3,11 +3,10 @@
 const ActionHandlerBase = require("@actions/actionHandlerBase");
 
 module.exports = class NotesActionHandler extends ActionHandlerBase {
-  help = "`!notes [message]` records a note.";
-
   constructor({ logger, notesActionPersistenceHandler }) {
     super(logger, "notes");
     this.persistenceHandler = notesActionPersistenceHandler;
+    this.help = "`!notes [message]` records a note.";
   }
 
   async handle(action, msg) {

--- a/app/actions/handlers/quoteActionHandler.js
+++ b/app/actions/handlers/quoteActionHandler.js
@@ -3,15 +3,13 @@
 const ActionHandlerBase = require("@actions/actionHandlerBase");
 
 module.exports = class QuoteActionHandler extends ActionHandlerBase {
-  help =
-    "`!quote <search>` finds a note (if `search` is omitted, I'll just find a random note).";
-
   constructor({ logger, notesActionPersistenceHandler }) {
     super(logger, "quote");
     this.persistenceHandler = notesActionPersistenceHandler;
+    this.help = "`!quote <search>` finds a note (if `search` is omitted, I'll just find a random note).";
   }
 
-  async handle(action, msg) {
+  async handle(action) {
     if (!action) {
       return;
     }

--- a/app/actions/persistenceHandlers/notesActionPersistenceHandler.spec.js
+++ b/app/actions/persistenceHandlers/notesActionPersistenceHandler.spec.js
@@ -5,7 +5,7 @@ const faker = require('faker'); // https://github.com/marak/Faker.js/
 
 describe("notesActionPersistenceHandler", () => {
   const logger = {
-    log: function (msg) { }
+    log: function () { }
   };
 
   it("sets logger to .logger property", () => {

--- a/app/actions/persistenceHandlers/notesActionPersistenceHandler.spec.js
+++ b/app/actions/persistenceHandlers/notesActionPersistenceHandler.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NotesActionPersistenceHandler = require("@actions/persistenceHandlers/notesActionPersistenceHandler");
-const faker = require('faker'); // https://github.com/marak/Faker.js/
+const faker = require('faker');
 
 describe("notesActionPersistenceHandler", () => {
   const logger = {
@@ -33,11 +33,11 @@ describe("notesActionPersistenceHandler", () => {
     var notesRepository = jasmine.createSpyObj("notesRepository", ["insertNote"])
     notesRepository.insertNote.and.returnValue(Promise.resolve());
 
-    const timestamp = faker.date.recent;
-    const userID = faker.random.number;
-    const channelID = faker.random.number;
+    const timestamp = faker.date.recent();
+    const userID = faker.random.number();
+    const channelID = faker.random.number();
     const nick = faker.userName;
-    const message = faker.lorem.sentence;
+    const message = faker.lorem.sentence();
 
     const handler = new NotesActionPersistenceHandler({ logger, notesRepository });
 
@@ -51,7 +51,7 @@ describe("notesActionPersistenceHandler", () => {
 
   it("insertNote returns repository.insertNote as result", async () => {
     // Arrange
-    const expectedResult = faker.fake;
+    const expectedResult = faker.random.objectElement();
     var notesRepository = jasmine.createSpyObj("notesRepository", ["insertNote"])
     notesRepository.insertNote.and.returnValue(expectedResult);
 
@@ -66,7 +66,7 @@ describe("notesActionPersistenceHandler", () => {
   //////////////////
   it("getRandomNote returns repository.getRandomNote as result", async () => {
     // Arrange
-    const expectedResult = faker.fake;
+    const expectedResult = faker.random.objectElement();
     var notesRepository = jasmine.createSpyObj("notesRepository", ["getRandomNote"])
     notesRepository.getRandomNote.and.returnValue(expectedResult);
 
@@ -83,7 +83,7 @@ describe("notesActionPersistenceHandler", () => {
     // Arrange
     var notesRepository = jasmine.createSpyObj("notesRepository", ["getRandomNoteByContent"])
     notesRepository.getRandomNoteByContent.and.returnValue(Promise.resolve());
-    const searchPhrase = faker.lorem.sentence;
+    const searchPhrase = faker.lorem.sentence();
 
     const handler = new NotesActionPersistenceHandler({ logger, notesRepository });
 
@@ -97,7 +97,7 @@ describe("notesActionPersistenceHandler", () => {
 
   it("getRandomNoteByContent returns repository.getRandomNoteByContent as result", async () => {
     // Arrange
-    const expectedResult = faker.fake;
+    const expectedResult = faker.random.objectElement();
     var notesRepository = jasmine.createSpyObj("notesRepository", ["getRandomNoteByContent"])
     notesRepository.getRandomNoteByContent.and.returnValue(expectedResult);
 

--- a/app/bot.js
+++ b/app/bot.js
@@ -44,7 +44,7 @@ module.exports = class Bot {
           resolve(true);
         });
 
-        this.client.login(this.appConfig.key);
+        this.client.login(this.appConfig.discord.key);
       } catch (e) {
         reject(e);
       }

--- a/app/container.js
+++ b/app/container.js
@@ -34,6 +34,7 @@ console.log("[Root] Registering services");
 container.register({
   bot: ioc.asClass(Bot, { lifetime: Lifetime.SINGLETON }),
   configFilePath: ioc.asValue("config.json"),
+  environment: ioc.asValue(process.env),
   dbConfig: ioc.asClass(DbConfig),
   appConfig: ioc.asFunction(Config),
   logger: ioc.asClass(Logger),

--- a/app/services/appConfig/appConfig.js
+++ b/app/services/appConfig/appConfig.js
@@ -2,7 +2,16 @@
 
 const fs = require("fs");
 
-module.exports = ({ configFilePath }) => {
+module.exports = ({ configFilePath, environment }) => {
   const config = JSON.parse(fs.readFileSync(configFilePath));
+  if (!environment) {
+    throw new Error("environment not found");
+  }
+  // Override secrets with specific env settings
+  config.discord.key = environment.BOT_DISCORD_KEY;
+  config.database.name = environment.BOT_DB_NAME;
+  config.database.server = environment.BOT_DB_SERVER;
+  config.database.user = environment.BOT_DB_USER;
+  config.database.password = environment.BOT_DB_PASSWORD;
   return config;
 }

--- a/app/services/appConfig/appConfig.spec.js
+++ b/app/services/appConfig/appConfig.spec.js
@@ -46,7 +46,7 @@ describe("appConfig", function () {
     expect(appConfig.database.name).toBe(expectedValue);
   });
 
-  it("sets environment BOT_DB_SERVER to database.name", function () {
+  it("sets environment BOT_DB_SERVER to database.server", function () {
     const expectedValue = faker.lorem.word();
     const configFilePath = "config.json";
     const environment = {
@@ -56,7 +56,7 @@ describe("appConfig", function () {
     expect(appConfig.database.server).toBe(expectedValue);
   });
 
-  it("sets environment BOT_DB_USER to database.name", function () {
+  it("sets environment BOT_DB_USER to database.user", function () {
     const expectedValue = faker.lorem.word();
     const configFilePath = "config.json";
     const environment = {
@@ -66,7 +66,7 @@ describe("appConfig", function () {
     expect(appConfig.database.user).toBe(expectedValue);
   });
 
-  it("sets environment BOT_DB_PASSWORD to database.name", function () {
+  it("sets environment BOT_DB_PASSWORD to database.password", function () {
     const expectedValue = faker.lorem.word();
     const configFilePath = "config.json";
     const environment = {

--- a/app/services/appConfig/appConfig.spec.js
+++ b/app/services/appConfig/appConfig.spec.js
@@ -1,19 +1,78 @@
 'use strict';
 
 const AppConfig = require("./appConfig");
+const faker = require('faker');
 
 describe("appConfig", function () {
   it("throws error if configFilePath is not found", function () {
     const configFilePath = "not_a_real_file";
     expect(function () {
-      AppConfig({ configFilePath: configFilePath });
-    }).toThrow();
+      AppConfig({ configFilePath });
+    }).toThrowError(`ENOENT: no such file or directory, open '${configFilePath}'`);
   });
 
-  it("parses json file contents as object", function () {
-    const configFilePath = "package.json";
-    const fileContents = AppConfig({ configFilePath: configFilePath });
-    expect(fileContents).toBeDefined();
-    expect(fileContents.name).toBe("corporal-lancot");
+  it("throws error if environment is not found", function () {
+    const configFilePath = "config.json";
+    expect(() => {
+      AppConfig({ configFilePath: configFilePath });
+    }).toThrowError("environment not found");
+  });
+
+  it("parses config.json file contents as object", function () {
+    const configFilePath = "config.json";
+    const environment = faker.fake;
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig).toBeDefined();
+  });
+
+  // Sensitive info mapping
+  it("sets environment BOT_DISCORD_KEY to discord.key", function () {
+    const expectedValue = faker.lorem.word();
+    const configFilePath = "config.json";
+    const environment = {
+      BOT_DISCORD_KEY: expectedValue
+    };
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig.discord.key).toBe(expectedValue);
+  });
+
+  it("sets environment BOT_DB_NAME to database.name", function () {
+    const expectedValue = faker.lorem.word();
+    const configFilePath = "config.json";
+    const environment = {
+      BOT_DB_NAME: expectedValue
+    };
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig.database.name).toBe(expectedValue);
+  });
+
+  it("sets environment BOT_DB_SERVER to database.name", function () {
+    const expectedValue = faker.lorem.word();
+    const configFilePath = "config.json";
+    const environment = {
+      BOT_DB_SERVER: expectedValue
+    };
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig.database.server).toBe(expectedValue);
+  });
+
+  it("sets environment BOT_DB_USER to database.name", function () {
+    const expectedValue = faker.lorem.word();
+    const configFilePath = "config.json";
+    const environment = {
+      BOT_DB_USER: expectedValue
+    };
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig.database.user).toBe(expectedValue);
+  });
+
+  it("sets environment BOT_DB_PASSWORD to database.name", function () {
+    const expectedValue = faker.lorem.word();
+    const configFilePath = "config.json";
+    const environment = {
+      BOT_DB_PASSWORD: expectedValue
+    };
+    const appConfig = AppConfig({ configFilePath, environment });
+    expect(appConfig.database.password).toBe(expectedValue);
   });
 });

--- a/app/services/db/adapters/mariaDbAdapter.spec.js
+++ b/app/services/db/adapters/mariaDbAdapter.spec.js
@@ -5,7 +5,7 @@ var theoretically = require("jasmine-theories");
 
 describe("mariaDbAdapter", () => {
   let logger = {
-    log: function (msg) { }
+    log: function () { }
   };
   let dbConfig = {
     connRetryCount: 0,
@@ -17,7 +17,7 @@ describe("mariaDbAdapter", () => {
     }
   };
   let fakeConnection = async () => {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       resolve(expectedConnection);
     })
   }

--- a/app/services/db/dbAdapterBase.spec.js
+++ b/app/services/db/dbAdapterBase.spec.js
@@ -5,7 +5,7 @@ const NotImplemented = require("@errors/notImplemented");
 
 describe("dbAdapterBase", () => {
   const logger = {
-    log: function (msg) { }
+    log: function () { }
   };
   const dbConfig = { };
 

--- a/app/services/db/dbConfig.js
+++ b/app/services/db/dbConfig.js
@@ -2,11 +2,24 @@
 
 module.exports = class DbConfig {
   constructor({ appConfig }) {
-    this.database = appConfig.db || "notes";
-    this.server = appConfig.dbHost || "localhost";
-    this.username = appConfig.dbUser;
-    this.password = appConfig.dbPassword;
-    this.connRetryCount = appConfig.dbConnectionRetryCount || 10;
-    this.connRetryDelay = appConfig.dbConnectionRetryDelay || 5000;
+    const databaseNameDefault = "notes";
+    const serverNameDefault = "localhost";
+    const connectionRetryCountDefault = 10;
+    const connectionRetryDelayDefault = 5000;
+
+    if (!appConfig.database) {
+      this.database = databaseNameDefault;
+      this.server = serverNameDefault;
+      this.connRetryCount = connectionRetryCountDefault;
+      this.connRetryDelay = connectionRetryDelayDefault;
+      return;
+    }
+
+    this.database = appConfig.database.name || databaseNameDefault;
+    this.server = appConfig.database.server || serverNameDefault;
+    this.username = appConfig.database.user;
+    this.password = appConfig.database.password;
+    this.connRetryCount = appConfig.database.connectionRetryCount || connectionRetryCountDefault;
+    this.connRetryDelay = appConfig.database.connectionRetryDelay || connectionRetryDelayDefault;
   }
 }

--- a/app/services/db/dbConfig.spec.js
+++ b/app/services/db/dbConfig.spec.js
@@ -3,73 +3,85 @@
 const DbConfig = require("./dbConfig");
 
 describe("dbConfig", function () {
-  it("maps injected appConfig.db property to .database", function () {
+  it("maps injected appConfig.database.name property to .database", function () {
     const appConfig = {
-      db: "test_database"
+      database: {
+        name: "test_database"
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.database).toBe(appConfig.db);
+    expect(dbConfig.database).toBe(appConfig.database.name);
   });
 
-  it("maps injected appConfig.dbHost property to .server", function () {
+  it("maps injected appConfig.database.server property to .server", function () {
     const appConfig = {
-      dbHost: "test_server"
+      database: {
+        server: "test_server"
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.server).toBe(appConfig.dbHost);
+    expect(dbConfig.server).toBe(appConfig.database.server);
   });
 
-  it("maps injected appConfig.dbUser property to .username", function () {
+  it("maps injected appConfig.database.user property to .username", function () {
     const appConfig = {
-      dbUser: "test_user"
+      database: {
+        user: "test_user"
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.username).toBe(appConfig.dbUser);
+    expect(dbConfig.username).toBe(appConfig.database.user);
   });
 
-  it("maps injected appConfig.dbPassword property to .password", function () {
+  it("maps injected appConfig.database.password property to .password", function () {
     const appConfig = {
-      dbPassword: "test_password"
+      database: {
+        password: "test_password"
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.password).toBe(appConfig.dbPassword);
+    expect(dbConfig.password).toBe(appConfig.database.password);
   });
 
-  it("maps injected appConfig.dbConnectionRetryCount property to .connRetryCount", function () {
+  it("maps injected appConfig.database.connectionRetryCount property to .connRetryCount", function () {
     const appConfig = {
-      dbConnectionRetryCount: 3
+      database: {
+        connectionRetryCount: 3
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.connRetryCount).toBe(appConfig.dbConnectionRetryCount);
+    expect(dbConfig.connRetryCount).toBe(appConfig.database.connectionRetryCount);
   });
 
-  it("maps injected appConfig.dbConnectionRetryDelay property to .connRetryDelay", function () {
+  it("maps injected appConfig.database.connectionRetryDelay property to .connRetryDelay", function () {
     const appConfig = {
-      dbConnectionRetryDelay: 3000
+      database: {
+        connectionRetryDelay: 3000
+      }
     };
     const dbConfig = new DbConfig({ appConfig: appConfig });
-    expect(dbConfig.connRetryDelay).toBe(appConfig.dbConnectionRetryDelay);
+    expect(dbConfig.connRetryDelay).toBe(appConfig.database.connectionRetryDelay);
   });
 
-  it("uses default value of 'localhost' for .server if appConfig.dbHost is empty", function () {
+  it("uses default value of 'localhost' for .server if appConfig property is empty", function () {
     const appConfig = {};
     const dbConfig = new DbConfig({ appConfig: appConfig });
     expect(dbConfig.server).toBe("localhost");
   });
 
-  it("uses default value of '10' for .connRetryCount if appConfig.dbConnectionRetryCount is empty", function () {
+  it("uses default value of '10' for .connRetryCount if appConfig property is empty", function () {
     const appConfig = {};
     const dbConfig = new DbConfig({ appConfig: appConfig });
     expect(dbConfig.connRetryCount).toBe(10);
   });
 
-  it("uses default value of '5000' for .connRetryDelay if appConfig.dbConnectionRetryDelay is empty", function () {
+  it("uses default value of '5000' for .connRetryDelay if appConfig property is empty", function () {
     const appConfig = {};
     const dbConfig = new DbConfig({ appConfig: appConfig });
     expect(dbConfig.connRetryDelay).toBe(5000);
   });
 
-  it("uses default value of 'notes' for .database if appConfig.db is empty", function () {
+  it("uses default value of 'notes' for .database if appConfig property is empty", function () {
     const appConfig = {};
     const dbConfig = new DbConfig({ appConfig: appConfig });
     expect(dbConfig.database).toBe("notes");

--- a/config.json
+++ b/config.json
@@ -1,0 +1,22 @@
+{
+  "discord": {
+    "key": null
+  },
+  "database": {
+    "name": null,
+    "server": null,
+    "user": null,
+    "password": null,
+    "connectionRetryCount": 10,
+    "connectionRetryDelay": 5000
+  },
+  "logging": {
+    "logLevel": "info",
+    "logTransports": [
+      "console",
+      "rolling"
+    ],
+    "logFileName": "bot.%DATE%.log",
+    "logTimestampFormat": "YYYY-MM-DD HH:mm:ss.SSS"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ version: "3.1"
 services:
   db:
     image: mariadb:10.5.3
-    container_name: corporallancot.db
+    container_name: ${BOT_DB_SERVER}
     ports:
-      - "${DB_LOCAL_PORT}:3306"
+      - "${BOT_DB_LOCAL_PORT}:3306"
     restart: "no"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -13,8 +13,8 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
     volumes:
-      - ${DB_MOUNT_PATH}:/var/lib/mysql
-      - ${DB_SQL_SCRIPTS_MOUNT_PATH}:/docker-entrypoint-initdb.d
+      - ${BOT_DB_MOUNT_PATH}:/var/lib/mysql
+      - ${BOT_DB_SQL_SCRIPTS_MOUNT_PATH}:/docker-entrypoint-initdb.d
   bot:
     image: corporallancot:latest
     container_name: corporallancot.bot
@@ -24,3 +24,9 @@ services:
       context: .
       dockerfile: Dockerfile
     restart: "no"
+    environment:
+      BOT_DISCORD_KEY: ${BOT_DISCORD_KEY}
+      BOT_DB_SERVER: ${BOT_DB_SERVER}
+      BOT_DB_NAME: ${MYSQL_DATABASE}
+      BOT_DB_USER: ${MYSQL_USER}
+      BOT_DB_PASSWORD: ${MYSQL_PASSWORD}

--- a/package-lock.json
+++ b/package-lock.json
@@ -387,6 +387,30 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "dotenv-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-3.1.0.tgz",
+      "integrity": "sha512-sT16Zg7m71IVP/MX2ZBm6JBu6fy8aEgN9kJPywaYhBZnmq7MSQbpvCEhuiGPI08X8G+CQ1Gj/oZZUH1lGvGmqA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1",
+        "dotenv": "^8.1.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.1.3"
+      }
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.3",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@discordjs/collection": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.5.tgz",
@@ -19,6 +45,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -26,6 +58,36 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -56,6 +118,21 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -99,6 +176,12 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camel-case": {
       "version": "4.1.1",
@@ -229,10 +312,36 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defaults": {
@@ -269,11 +378,29 @@
         "ws": "^7.2.1"
       }
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz",
+      "integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -281,10 +408,195 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.3.0.tgz",
+      "integrity": "sha512-dJMVXwfU5PT1cj2Nv2VPPrKahKTGdX+5Dh0Q3YuKt+Y2UhdL2YbzsVaBMyG9HC0tBismlv/r1+eZqs6SMIV38Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.2.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.2.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "event-target-shim": {
       "version": "5.0.1",
@@ -296,6 +608,33 @@
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
       "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -315,6 +654,23 @@
         "locate-path": "^3.0.0"
       }
     },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -326,6 +682,12 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "generate-function": {
       "version": "2.3.1",
@@ -363,6 +725,15 @@
         "is-glob": "^4.0.1"
       }
     },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -376,6 +747,28 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -432,6 +825,12 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "jasmine": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
@@ -468,6 +867,44 @@
       "integrity": "sha512-96E+GmSYZZr3H+bmtHrJSGSiUwRKUlKID/vM9OlI3L7RXJ0VwpsQUE2ueVH6nQvgGxt6ow0p7hxusuNG7QzbxA==",
       "dev": true
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -477,6 +914,12 @@
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -553,10 +996,31 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "module-alias": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "mysql2": {
       "version": "2.1.0",
@@ -597,6 +1061,12 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "no-case": {
       "version": "3.0.3",
@@ -644,6 +1114,20 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -682,6 +1166,15 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "pascal-case": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
@@ -702,6 +1195,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "perfy": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/perfy/-/perfy-1.1.5.tgz",
@@ -714,15 +1213,33 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "prism-media": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
       "integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "readdirp": {
       "version": "3.4.0",
@@ -741,6 +1258,12 @@
         "esprima": "~4.0.0"
       }
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -753,6 +1276,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -763,10 +1292,25 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
     },
     "seq-queue": {
       "version": "0.0.5",
@@ -784,10 +1328,42 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sqlstring": {
@@ -815,6 +1391,12 @@
         "ansi-regex": "^4.1.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -823,6 +1405,24 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -843,6 +1443,36 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -852,10 +1482,25 @@
         "defaults": "^1.0.3"
       }
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrap-ansi": {
@@ -873,6 +1518,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "ws": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "docker:stop": "docker-compose down",
     "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
     "test": "jasmine",
-    "test:watch": "chokidar -p \"**/*.js\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500"
+    "test:watch": "chokidar -p \"**/*.js\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500",
+    "lint": "eslint .",
+    "lint:watch": "chokidar -p \"**/*.js\" --ignore \"node_modules/**/*\" -c \"npm run lint\" --initial --debounce 500"
   },
   "dependencies": {
     "awilix": "^4.2.6",
@@ -20,6 +22,7 @@
   },
   "devDependencies": {
     "chokidar-cli": "^2.1.0",
+    "eslint": "^7.3.0",
     "faker": "^4.1.0",
     "jasmine": "^3.5.0",
     "jasmine-console-reporter": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "author": "Lewis 'SEPTiMUS' Lane",
   "scripts": {
-    "start": "node index.js",
+    "start": "dotenv -- node index.js",
+    "start:hosted": "node index.js",
     "docker:start": "docker-compose up -d --build",
     "docker:stop": "docker-compose down",
-    "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
+    "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js,.env}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
     "test": "jasmine",
     "test:watch": "chokidar -p \"{**/*.js,package.json,spec/support/jasmine.json}\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500",
     "lint": "eslint .",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "chokidar-cli": "^2.1.0",
+    "dotenv-cli": "^3.1.0",
     "eslint": "^7.3.0",
     "faker": "^4.1.0",
     "jasmine": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "docker:stop": "docker-compose down",
     "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
     "test": "jasmine",
-    "test:watch": "chokidar -p \"**/*.js\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500",
+    "test:watch": "chokidar -p \"{**/*.js,package.json,spec/support/jasmine.json}\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500",
     "lint": "eslint .",
-    "lint:watch": "chokidar -p \"**/*.js\" --ignore \"node_modules/**/*\" -c \"npm run lint\" --initial --debounce 500"
+    "lint:watch": "chokidar -p \"{**/*.js,.eslintrc.json,package.json}\" --ignore \"node_modules/**/*\" -c \"npm run lint\" --initial --debounce 500"
   },
   "dependencies": {
     "awilix": "^4.2.6",


### PR DESCRIPTION
This is the "CI" portion of #19 - please leave the branch intact and I will get the CD / package publication working next.

This PR introduces a number of significant changes:

- `config.json` is now pushed to the repo. All sensitive information has been moved into `.env`, which is not pushed (and should never be).
- A `.env` file is now _required_ to run the bot in either "local dev mode" (i.e. `npm start`) or in docker (i.e. `npm run docker:start`).
  - The docker process has been updated in README.md
  - Local dev mode requires less variables (not documented, just ask me)
- ESLint has been added and now runs as part of the CI build, reporting basic linting errors up to es2020
- `config.json` now has sections, though I have not yet abstracted them all into their own classes - this will be done in the coming weeks!
- `npm start` now runs `dotenv`, which essentially parses the `.env` file for development.
- The docker container no longer runs `npm start`, a new task - `npm run start:hosted` has been created which is the same as the old `npm start` command (`.env` is read as part of the docker environment bootstrap sequence, and environment variables are scoped for each container in `docker-compose.yml`, so it is not required)

**Minor changes**
- Fixed up a number of linting errors
- Fixed up some uses of faker.js that were incorrectly setting strings to objects / functions. Tests still passed though, because JavaScript ;)
- Prefixed all bot specific environment variables with `BOT_` to distinguish them from others (such as `MYSQL_`)

Please review and PR this into master so we can start getting CI feedback in all our branches - I'll create another PR for the CD work from the same branch.