### PR TITLE
#18 config abstraction

### DIFF
--- a/app/bot.js
+++ b/app/bot.js
@@ -7,15 +7,13 @@ module.exports = class Bot {
     discordChatListenerConfig,
     actions,
     discord,
-    botVersion,
-    botName,
-    botDescription,
+    botConfig,
     logger
   }) {
     this.logPrefix = `[${this.constructor.name}] `;
     this.logger = logger;
-    this.logger.log(`${this.logPrefix}*** Welcome to ${botName} v${botVersion}! ***`);
-    this.logger.log(`${this.logPrefix}*** ${botDescription} ***`);
+    this.logger.log(`${this.logPrefix}*** Welcome to ${botConfig.name} v${botConfig.version}! ***`);
+    this.logger.log(`${this.logPrefix}*** ${botConfig.description} ***`);
 
     this.actions = actions;
     this.discordToken = discordChatListenerConfig.token;

--- a/app/bot.js
+++ b/app/bot.js
@@ -4,7 +4,7 @@ const DiscordMessage = require("./actions/actionMessage");
 
 module.exports = class Bot {
   constructor({
-    appConfig,
+    discordChatListenerConfig,
     actions,
     discord,
     botVersion,
@@ -18,13 +18,8 @@ module.exports = class Bot {
     this.logger.log(`${this.logPrefix}*** ${botDescription} ***`);
 
     this.actions = actions;
-    this.appConfig = appConfig;
+    this.discordToken = discordChatListenerConfig.token;
     this.discord = discord;
-
-    // TODO: Fix this up for new deps!
-    if (!this.discord || !this.actions || !this.appConfig) {
-      throw new Error("Missing required constructor dependencies");
-    }
   }
 
   async init() {
@@ -44,7 +39,7 @@ module.exports = class Bot {
           resolve(true);
         });
 
-        this.client.login(this.appConfig.discord.key);
+        this.client.login(this.discordToken);
       } catch (e) {
         reject(e);
       }

--- a/app/botConfig.js
+++ b/app/botConfig.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = class BotConfig {
+  constructor({ appConfig, environment }) {
+    const defaultName = "Corporal Lancot";
+    const defaultDescription = "Halt!";
+    const defaultVersion = "1.0.0";
+
+    if (!appConfig && !environment) {
+      throw new Error("Either the 'bot' property should be set in the config file, or the bot should be executed via an npm script so it has access to npm environment settings.");
+    }
+
+    // Defaults
+    this.name = defaultName;
+    this.description = defaultDescription;
+    this.version = defaultVersion;
+
+    // package.json settings take precedence over defaults
+    if (environment) {
+      this.name = this.coalesce(environment.npm_package_name, this.name);
+      this.description = this.coalesce(environment.npm_package_description, this.description);
+      this.version = this.coalesce(environment.npm_package_version, this.version);
+    }
+
+    // Config settings take precedence over package.json and defaults
+    if (appConfig.bot) {
+      this.name = this.coalesce(appConfig.bot.name, this.name);
+      this.description = this.coalesce(appConfig.bot.description, this.description);
+      this.version = this.coalesce(appConfig.bot.version, this.version);
+    }
+  }
+
+  coalesce(input, defaultValue) {
+    if (input === null || input === undefined || input.match(/^\s*$/g)) {
+      return defaultValue;
+    }
+    return input;
+  }
+}

--- a/app/botConfig.spec.js
+++ b/app/botConfig.spec.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const BotConfig = require("./botConfig");
+var theoretically = require("jasmine-theories");
+
+describe("botConfig", function () {
+  it("maps injected appConfig.bot.name property to .name", () => {
+    // Arrange
+    const appConfig = {
+      bot: {
+        name: "Jeff"
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig });
+
+    // Assert
+    expect(actualResult.name).toBe(appConfig.bot.name);
+  });
+
+  it("maps injected appConfig.bot.version property to .version", () => {
+    // Arrange
+    const appConfig = {
+      bot: {
+        version: "1.0.0"
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig });
+
+    // Assert
+    expect(actualResult.version).toBe(appConfig.bot.version);
+  });
+
+  it("maps injected appConfig.bot.description property to .description", () => {
+    // Arrange
+    const appConfig = {
+      bot: {
+        description: "Jeff is a..."
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig });
+
+    // Assert
+    expect(actualResult.description).toBe(appConfig.bot.description);
+  });
+
+  it("throws exception if config and environment are undefined", () => {
+    // Act & Assert
+    expect(() => {
+      new BotConfig({});
+    }).toThrowError("Either the 'bot' property should be set in the config file, or the bot should be executed via an npm script so it has access to npm environment settings.");
+  });
+
+  it("sets defaults if appConfig defined but has no properties", () => {
+    // Arrange
+    const environment = {};
+    const appConfig = {};
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.name).toBe("Corporal Lancot");
+    expect(actualResult.description).toBe("Halt!");
+    expect(actualResult.version).toBe("1.0.0");
+  });
+
+  theoretically.it("uses npm_package_name if appConfig.bot.name is '%s'", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = {
+      npm_package_name: "expected-name"
+    };
+    const appConfig = {
+      bot: {
+        name: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.name).toBe(environment.npm_package_name);
+  });
+
+  theoretically.it("uses npm_package_version if appConfig.bot.version is '%s'", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = {
+      npm_package_version: "expected-version"
+    };
+    const appConfig = {
+      bot: {
+        version: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.version).toBe(environment.npm_package_version);
+  });
+
+  theoretically.it("uses npm_package_description if appConfig.bot.name is '%s'", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = {
+      npm_package_description: "expected-desc"
+    };
+    const appConfig = {
+      bot: {
+        description: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.description).toBe(environment.npm_package_description);
+  });
+
+  theoretically.it("uses default name if appConfig.bot.name is '%s' and environment undefined", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = undefined;
+    const appConfig = {
+      bot: {
+        name: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.name).toBe("Corporal Lancot");
+  });
+
+  theoretically.it("uses default version if appConfig.bot.version is '%s' and environment undefined", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = undefined;
+    const appConfig = {
+      bot: {
+        version: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.version).toBe("1.0.0");
+  });
+
+  theoretically.it("uses default description if appConfig.bot.name is '%s' and environment undefined", [null, "", " ", undefined], (insertedValue) => {
+    // Arrange
+    const environment = undefined;
+    const appConfig = {
+      bot: {
+        description: insertedValue
+      }
+    };
+
+    // Act
+    const actualResult = new BotConfig({ appConfig, environment });
+
+    // Assert
+    expect(actualResult.description).toBe("Halt!");
+  });
+});

--- a/app/container.js
+++ b/app/container.js
@@ -8,6 +8,7 @@ const Lifetime = ioc.Lifetime;
 const Bot = require('@root/bot');
 // Config
 const Config = require('@services/appConfig/appConfig');
+const BotConfig = require('@root/botConfig');
 const DbConfig = require('@services/db/dbConfig');
 const DiscordChatListenerConfig = require('@chatListeners/discord/discordChatListenerConfig');
 
@@ -43,9 +44,7 @@ container.register({
   appConfig: ioc.asFunction(Config),
   dbConfig: ioc.asClass(DbConfig),
   discordChatListenerConfig: ioc.asClass(DiscordChatListenerConfig),
-  botVersion: ioc.asValue(process.env.npm_package_version),
-  botName: ioc.asValue(process.env.npm_package_name),
-  botDescription: ioc.asValue(process.env.npm_package_description),
+  botConfig: ioc.asClass(BotConfig),
   // Logging
   logger: ioc.asClass(Logger),
   // 3rd Party

--- a/app/container.js
+++ b/app/container.js
@@ -6,10 +6,13 @@ const Lifetime = ioc.Lifetime;
 
 // App
 const Bot = require('@root/bot');
-// Services
-const DbConfig = require('@services/db/dbConfig');
-const DbAdapter = require('@dbAdapters/mariaDbAdapter');
+// Config
 const Config = require('@services/appConfig/appConfig');
+const DbConfig = require('@services/db/dbConfig');
+const DiscordChatListenerConfig = require('@chatListeners/discord/discordChatListenerConfig');
+
+// Services
+const DbAdapter = require('@dbAdapters/mariaDbAdapter');
 const Logger = require('@services/logging/logger');
 // Actions
 const HelpActionHandler = require("@actions/handlers/helpActionHandler");
@@ -32,17 +35,22 @@ const container = ioc.createContainer({
 console.log("[Root] Registering services");
 
 container.register({
+  // Bootstrap
   bot: ioc.asClass(Bot, { lifetime: Lifetime.SINGLETON }),
+  // Config
   configFilePath: ioc.asValue("config.json"),
   environment: ioc.asValue(process.env),
-  dbConfig: ioc.asClass(DbConfig),
   appConfig: ioc.asFunction(Config),
-  logger: ioc.asClass(Logger),
-  mySql: ioc.asValue(MySQL),
-  discord: ioc.asValue(Discord),
+  dbConfig: ioc.asClass(DbConfig),
+  discordChatListenerConfig: ioc.asClass(DiscordChatListenerConfig),
   botVersion: ioc.asValue(process.env.npm_package_version),
   botName: ioc.asValue(process.env.npm_package_name),
   botDescription: ioc.asValue(process.env.npm_package_description),
+  // Logging
+  logger: ioc.asClass(Logger),
+  // 3rd Party
+  mySql: ioc.asValue(MySQL),
+  discord: ioc.asValue(Discord),
 
   // Register Action persistence handlers - TODO: Register automatically
   notesActionPersistenceHandler: ioc.asClass(NotesActionPersistenceHandler, { lifetime: Lifetime.SINGLETON }),

--- a/app/services/chatListeners/discord/discordChatListenerConfig.js
+++ b/app/services/chatListeners/discord/discordChatListenerConfig.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = class DiscordChatListenerConfig {
+  constructor({ appConfig }) {
+    if (appConfig.discord) {
+      this.token = appConfig.discord.key;
+      return;
+    }
+
+    // Defaults
+    this.token = null;
+  }
+}

--- a/app/services/chatListeners/discord/discordChatListenerConfig.spec.js
+++ b/app/services/chatListeners/discord/discordChatListenerConfig.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const DiscordChatListenerConfig = require("./discordChatListenerConfig");
+
+describe("discordChatListenerConfig", function () {
+  it("maps injected appConfig.discord.key property to .token", () => {
+    // Arrange
+    const appConfig = {
+      discord: {
+        key: "mytestkey"
+      }
+    };
+
+    // Act
+    const actualResult = new DiscordChatListenerConfig({ appConfig });
+
+    // Assert
+    expect(actualResult.token).toBe(appConfig.discord.key);
+  });
+
+  it("returns null .token when discord property is not defined in config file", () => {
+    // Arrange
+    const appConfig = {};
+
+    // Act
+    const actualResult = new DiscordChatListenerConfig({ appConfig })
+
+    // Assert
+    expect(actualResult.token).toBe(null);
+  });
+});

--- a/config.json
+++ b/config.json
@@ -1,4 +1,9 @@
 {
+  "bot": {
+    "name": null,
+    "version": null,
+    "description": null
+  },
   "discord": {
     "key": null
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start:hosted": "node index.js",
     "docker:start": "docker-compose up -d --build",
     "docker:stop": "docker-compose down",
-    "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js,.env}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
+    "docker:watch": "chokidar -p \"{docker-compose.yml,Dockerfile,.dockerignore,package.json,**/*.js,.env,config.json}\" --ignore \"{**/*.spec.js,node_modules/**/*,spec/**/*}\" -c \"npm run docker:start && docker logs corporallancot.bot\" --initial --debounce 1000",
     "test": "jasmine",
     "test:watch": "chokidar -p \"{**/*.js,package.json,spec/support/jasmine.json}\" --ignore \"node_modules/**/*\" -c \"npm run test\" --initial --debounce 500",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@services": "app/services",
     "@errors": "app/errors",
     "@dbRepositories": "app/services/db/repositories",
-    "@dbAdapters": "app/services/db/adapters"
+    "@dbAdapters": "app/services/db/adapters",
+    "@chatListeners": "app/services/chatListeners"
   }
 }


### PR DESCRIPTION
Closes #18 [except for logging config] - Implemented Discord listener and Bot config abstractions

- Added Discord Config abstraction class
- Added into new chatListeners directory structure in anticipation for discord listener abstraction and multi-server implementation
- Changed the injection into Bot.js to use the new discordChatListenerConfig until the discord code is further abstracted
- The bot now uses the injected BotConfig class for reading bot level configuration values (name, version, description - will be expanded as features are added)
- The BotConfig class reads settings from various different sources with the following precedence (highest to lowest priority); config file, npm environment, hard coded defaults

